### PR TITLE
Launch official Feedbax dogfood workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Feedbax roadmap item
+
+Feedbax item: <!-- Required: https://feedbax-feedback.jessefquartey.workers.dev/feedback/<id> -->
+
+<!-- A maintainer may instead apply `feedbax-exempt` and explain why below. -->
+
+Maintainer exception reason:
+
+## What changed
+
+## Validation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  contribution-reference:
+    name: Contribution / Feedbax item
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/check-contribution-reference.mjs
+
   dependencies:
     name: Quality / Dependencies
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,16 @@
 # Contributing
 
-Feedbax is preparing the v0.1.0 pre-launch rebuild. Issues, workflow descriptions, and design feedback are welcome now; implementation contributions should align with an accepted issue or RFC.
+Feedbax uses its own public portal as the canonical roadmap and contribution queue: https://feedbax-feedback.jessefquartey.workers.dev. Implementation contributions must start from an accepted Feedbax item.
 
 ## Before contributing
 
-1. Search existing issues and discussions.
-2. Open an issue describing the user problem, not only an implementation.
-3. Wait for scope agreement before starting a large change.
-4. Keep pull requests focused and update relevant documentation and tests.
+1. Search the Feedbax portal and vote for an existing item before creating a duplicate.
+2. Submit the user problem to the portal when no item exists, then wait for scope agreement before starting a large change.
+3. Use GitHub issues for implementation discussion only after linking the canonical Feedbax item.
+4. Include the canonical item URL in the pull-request template.
+5. Keep pull requests focused and update relevant documentation and tests.
+
+Pull requests without a Feedbax item fail CI. A maintainer may apply the `feedbax-exempt` label only for a security fix, urgent regression, or repository-only maintenance and must record the reason in the pull-request body.
 
 ## Expectations
 

--- a/README.md
+++ b/README.md
@@ -70,3 +70,6 @@ Feedbax is MIT licensed. The v0.1.0 APIs remain preview interfaces.
 
 Feedbax uses its own public portal for feature requests, roadmap updates, and
 rollout issues: [Feedbax feedback](https://feedbax-feedback.jessefquartey.workers.dev).
+
+- [Marketing and documentation](https://feedbax-docs.jessefquartey.workers.dev)
+- [Duplicable Notion starter](https://brave-number-c98.notion.site/Feedbax-Notion-Starter-39dafe1596918155a94cc24a1a41a2a5)

--- a/apps/portal/package.json
+++ b/apps/portal/package.json
@@ -26,6 +26,7 @@
     "@tanstack/react-db": "0.1.92",
     "@tanstack/react-router": "1.170.17",
     "@tanstack/react-start": "1.168.27",
+    "jose": "6.1.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/apps/portal/src/auth.server.ts
+++ b/apps/portal/src/auth.server.ts
@@ -4,9 +4,11 @@ import {
   type IdentityProvider,
   type SigningKeyConfig,
 } from '@feedbax/auth-handoff'
+import { SignJWT, base64url } from 'jose'
 import { readEnv } from './spike.js'
 
 let instance: IdentityProvider | undefined
+let emailExchangeProvider: SignedHandoffIdentityProvider | undefined
 
 function parseArray<T>(name: string): readonly T[] {
   const value = readEnv(name)
@@ -22,6 +24,48 @@ function parseArray<T>(name: string): readonly T[] {
 
 export function authProvider(): IdentityProvider {
   if (instance) return instance
+  if (readEnv('FEEDBAX_IDENTITY_MODE') === 'email') {
+    const secret = readEnv('FEEDBAX_SESSION_SECRET')
+    if (!secret || new TextEncoder().encode(secret).byteLength < 32)
+      throw new Error(
+        'FEEDBAX_SESSION_SECRET must contain at least 32 bytes for email identity.',
+      )
+    const keyBytes = new TextEncoder().encode(secret).slice(0, 32)
+    const key = {
+      id: 'email-2026-07',
+      secret: base64url.encode(keyBytes),
+    }
+    emailExchangeProvider = new SignedHandoffIdentityProvider({
+      audience: 'feedbax',
+      issuers: [{ issuer: 'feedbax:email', keys: [key] }],
+      sessionKeys: [key],
+      activeSessionKeyId: key.id,
+      loginUrl: `${readEnv('FEEDBAX_PUBLIC_URL') ?? 'http://localhost:3000'}/auth/email`,
+    })
+    const provider = emailExchangeProvider
+    instance = {
+      id: 'email',
+      currentSession: (request) => provider.currentSession(request),
+      requireAuthentication: (request) =>
+        provider.requireAuthentication(request),
+      publicUser: (session) => provider.publicUser(session),
+      loginRedirect: (request, returnPath = '/') => {
+        const destination = new URL('/auth/email', request.url)
+        destination.searchParams.set('return_path', returnPath)
+        return Promise.resolve(
+          new Response(null, {
+            status: 303,
+            headers: {
+              location: destination.toString(),
+              'cache-control': 'private, no-store',
+            },
+          }),
+        )
+      },
+      logout: (request, returnPath) => provider.logout(request, returnPath),
+    }
+    return instance
+  }
   const activeSessionKeyId = readEnv('FEEDBAX_AUTH_ACTIVE_SESSION_KEY_ID')
   const loginUrl = readEnv('FEEDBAX_AUTH_LOGIN_URL')
   if (!activeSessionKeyId || !loginUrl)
@@ -36,4 +80,35 @@ export function authProvider(): IdentityProvider {
     loginUrl,
   })
   return instance
+}
+
+export async function createEmailSession(
+  email: string,
+  returnPath: string,
+): Promise<{ cookie: string; returnPath: string }> {
+  const normalized = email.trim().toLowerCase()
+  if (!/^\S+@\S+\.\S+$/.test(normalized))
+    throw new Error('Enter a valid email address.')
+  const secret = readEnv('FEEDBAX_SESSION_SECRET')
+  if (!secret) throw new Error('Email identity is not configured.')
+  const now = Math.floor(Date.now() / 1000)
+  const key = new TextEncoder().encode(secret).slice(0, 32)
+  const token = await new SignJWT({
+    email: normalized,
+    name: 'Customer',
+    return_path: returnPath,
+  })
+    .setProtectedHeader({ alg: 'HS256', kid: 'email-2026-07' })
+    .setIssuer('feedbax:email')
+    .setAudience('feedbax')
+    .setSubject(normalized)
+    .setJti(crypto.randomUUID())
+    .setIssuedAt(now)
+    .setExpirationTime(now + 300)
+    .sign(key)
+  authProvider()
+  if (!emailExchangeProvider)
+    throw new Error('Email identity is not configured.')
+  const exchanged = await emailExchangeProvider.exchange(token)
+  return { cookie: exchanged.cookie, returnPath: exchanged.returnPath }
 }

--- a/apps/portal/src/routeTree.gen.ts
+++ b/apps/portal/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as FeedbackIdRouteImport } from './routes/feedback.$id'
 import { Route as ChangelogSlugRouteImport } from './routes/changelog_.$slug'
 import { Route as AuthLogoutRouteImport } from './routes/auth.logout'
 import { Route as AuthHandoffRouteImport } from './routes/auth.handoff'
+import { Route as AuthEmailRouteImport } from './routes/auth.email'
 import { Route as ApiVoteStateRouteImport } from './routes/api.vote-state'
 import { Route as ApiVoteRouteImport } from './routes/api.vote'
 import { Route as ApiTestConnectorRouteImport } from './routes/api.test-connector'
@@ -63,6 +64,11 @@ const AuthLogoutRoute = AuthLogoutRouteImport.update({
 const AuthHandoffRoute = AuthHandoffRouteImport.update({
   id: '/auth/handoff',
   path: '/auth/handoff',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthEmailRoute = AuthEmailRouteImport.update({
+  id: '/auth/email',
+  path: '/auth/email',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiVoteStateRoute = ApiVoteStateRouteImport.update({
@@ -146,6 +152,7 @@ export interface FileRoutesByFullPath {
   '/api/test-connector': typeof ApiTestConnectorRoute
   '/api/vote': typeof ApiVoteRoute
   '/api/vote-state': typeof ApiVoteStateRoute
+  '/auth/email': typeof AuthEmailRoute
   '/auth/handoff': typeof AuthHandoffRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/changelog/$slug': typeof ChangelogSlugRoute
@@ -168,6 +175,7 @@ export interface FileRoutesByTo {
   '/api/test-connector': typeof ApiTestConnectorRoute
   '/api/vote': typeof ApiVoteRoute
   '/api/vote-state': typeof ApiVoteStateRoute
+  '/auth/email': typeof AuthEmailRoute
   '/auth/handoff': typeof AuthHandoffRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/changelog/$slug': typeof ChangelogSlugRoute
@@ -191,6 +199,7 @@ export interface FileRoutesById {
   '/api/test-connector': typeof ApiTestConnectorRoute
   '/api/vote': typeof ApiVoteRoute
   '/api/vote-state': typeof ApiVoteStateRoute
+  '/auth/email': typeof AuthEmailRoute
   '/auth/handoff': typeof AuthHandoffRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/changelog_/$slug': typeof ChangelogSlugRoute
@@ -215,6 +224,7 @@ export interface FileRouteTypes {
     | '/api/test-connector'
     | '/api/vote'
     | '/api/vote-state'
+    | '/auth/email'
     | '/auth/handoff'
     | '/auth/logout'
     | '/changelog/$slug'
@@ -237,6 +247,7 @@ export interface FileRouteTypes {
     | '/api/test-connector'
     | '/api/vote'
     | '/api/vote-state'
+    | '/auth/email'
     | '/auth/handoff'
     | '/auth/logout'
     | '/changelog/$slug'
@@ -259,6 +270,7 @@ export interface FileRouteTypes {
     | '/api/test-connector'
     | '/api/vote'
     | '/api/vote-state'
+    | '/auth/email'
     | '/auth/handoff'
     | '/auth/logout'
     | '/changelog_/$slug'
@@ -282,6 +294,7 @@ export interface RootRouteChildren {
   ApiTestConnectorRoute: typeof ApiTestConnectorRoute
   ApiVoteRoute: typeof ApiVoteRoute
   ApiVoteStateRoute: typeof ApiVoteStateRoute
+  AuthEmailRoute: typeof AuthEmailRoute
   AuthHandoffRoute: typeof AuthHandoffRoute
   AuthLogoutRoute: typeof AuthLogoutRoute
   ChangelogSlugRoute: typeof ChangelogSlugRoute
@@ -337,6 +350,13 @@ declare module '@tanstack/react-router' {
       path: '/auth/handoff'
       fullPath: '/auth/handoff'
       preLoaderRoute: typeof AuthHandoffRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/email': {
+      id: '/auth/email'
+      path: '/auth/email'
+      fullPath: '/auth/email'
+      preLoaderRoute: typeof AuthEmailRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/vote-state': {
@@ -462,6 +482,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiTestConnectorRoute: ApiTestConnectorRoute,
   ApiVoteRoute: ApiVoteRoute,
   ApiVoteStateRoute: ApiVoteStateRoute,
+  AuthEmailRoute: AuthEmailRoute,
   AuthHandoffRoute: AuthHandoffRoute,
   AuthLogoutRoute: AuthLogoutRoute,
   ChangelogSlugRoute: ChangelogSlugRoute,

--- a/apps/portal/src/routes/auth.email.ts
+++ b/apps/portal/src/routes/auth.email.ts
@@ -1,0 +1,54 @@
+import { safeReturnPath } from '@feedbax/auth-handoff'
+import { createFileRoute } from '@tanstack/react-router'
+import { createEmailSession } from '../auth.server.js'
+
+const page = (returnPath: string, error = '') => `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Continue to Feedbax</title><style>
+body{font:16px/1.5 system-ui;margin:0;background:#f6f7fb;color:#25273d}main{max-width:28rem;margin:12vh auto;padding:2rem;background:#fff;border:1px solid #d4d7e1;border-radius:1rem}label{display:block;font-weight:650;margin-bottom:.5rem}input,button{box-sizing:border-box;width:100%;padding:.75rem;border-radius:.5rem;font:inherit}input{border:1px solid #9aa1b2}button{margin-top:1rem;border:0;background:#2563eb;color:#fff;font-weight:700}p{color:#626a80}.error{color:#b42318}</style></head>
+<body><main><h1>Continue with email</h1><p>Enter an email so the Feedbax team can follow up. Ownership is not verified.</p>
+${error ? `<p class="error" role="alert">${error}</p>` : ''}
+<form method="post"><input type="hidden" name="return_path" value="${returnPath}"><label for="email">Email address</label><input id="email" name="email" type="email" autocomplete="email" required><button type="submit">Continue</button></form></main></body></html>`
+
+export const Route = createFileRoute('/auth/email')({
+  server: {
+    handlers: {
+      GET: ({ request }) => {
+        const returnPath = safeReturnPath(
+          new URL(request.url).searchParams.get('return_path'),
+        )
+        return new Response(page(returnPath), {
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        })
+      },
+      POST: async ({ request }) => {
+        const origin = request.headers.get('origin')
+        if (origin && origin !== new URL(request.url).origin)
+          return new Response('Origin rejected.', { status: 403 })
+        const form = await request.formData()
+        const email = String(form.get('email') ?? '')
+        const returnPath = safeReturnPath(
+          String(form.get('return_path') ?? '/'),
+        )
+        try {
+          const session = await createEmailSession(email, returnPath)
+          return new Response(null, {
+            status: 303,
+            headers: {
+              location: session.returnPath,
+              'set-cookie': session.cookie,
+              'cache-control': 'private, no-store',
+            },
+          })
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Email could not be saved.'
+          return new Response(page(returnPath, message), {
+            status: 422,
+            headers: { 'content-type': 'text/html; charset=utf-8' },
+          })
+        }
+      },
+    },
+  },
+})

--- a/apps/portal/wrangler.jsonc
+++ b/apps/portal/wrangler.jsonc
@@ -8,9 +8,7 @@
   "vars": {
     "FEEDBAX_PUBLIC_URL": "https://feedbax-feedback.jessefquartey.workers.dev",
     "FEEDBAX_RATE_LIMIT_STORE": "cloudflare",
-    "FEEDBAX_AUTH_AUDIENCE": "feedbax",
-    "FEEDBAX_AUTH_LOGIN_URL": "https://feedbax-dogfood-auth.jessefquartey.workers.dev/login",
-    "FEEDBAX_AUTH_ACTIVE_SESSION_KEY_ID": "session-2026-07",
+    "FEEDBAX_IDENTITY_MODE": "email",
   },
   "durable_objects": {
     "bindings": [

--- a/apps/site/README.md
+++ b/apps/site/README.md
@@ -10,3 +10,5 @@ pnpm --filter @feedbax/site build
 The production build writes static assets and prerendered HTML to `.output/public`. Deploy that directory to any static host or CDN. Configure an SPA fallback to `_shell.html` (or copy it to the host's expected fallback path) for unknown client-side routes.
 
 Set `VITE_SITE_URL` during the build to emit an absolute canonical URL. The variable is optional; the build has no portal, Notion, or server-secret dependency.
+
+Deploy the verified output to the `feedbax-docs` Worker with `pnpm deploy:cloudflare`, then run `pnpm smoke -- https://feedbax-docs.jessefquartey.workers.dev`.

--- a/apps/site/content/docs/contributing.mdx
+++ b/apps/site/content/docs/contributing.mdx
@@ -3,14 +3,17 @@ title: Contributing
 description: Help shape Feedbax while its first public interfaces are still forming.
 ---
 
-Issues, workflow descriptions, and design feedback are welcome now. Implementation contributions should align with an accepted issue or RFC.
+Feedbax's own public portal is the canonical roadmap and contribution queue. Implementation contributions must align with an accepted portal item.
 
 ## Before contributing
 
-1. Search existing issues and discussions.
-2. Open an issue describing the user problem, not only an implementation.
-3. Wait for scope agreement before starting a large change.
-4. Keep pull requests focused and update relevant documentation and tests.
+1. Search the Feedbax portal and vote for an existing item before creating a duplicate.
+2. Submit the user problem to the portal when no item exists and wait for scope agreement.
+3. Use GitHub issues for implementation discussion only after linking the canonical Feedbax item.
+4. Include the portal item's `/feedback/<id>` URL in the pull request.
+5. Keep pull requests focused and update relevant documentation and tests.
+
+Pull requests without a Feedbax item fail CI. A maintainer may apply `feedbax-exempt` only for a security fix, urgent regression, or repository-only maintenance and must record the reason in the pull-request body.
 
 ## Local checks
 

--- a/apps/site/content/docs/deployment.mdx
+++ b/apps/site/content/docs/deployment.mdx
@@ -15,6 +15,17 @@ Deploy the generated static client directory at `apps/site/.output/public` to an
 
 Search runs entirely in the browser. The site does not need portal APIs, Notion credentials, or a long-running Node server.
 
+The repository includes a Cloudflare Workers asset preset:
+
+```sh
+VITE_SITE_URL=https://feedbax-docs.jessefquartey.workers.dev \
+  pnpm --filter @feedbax/site deploy:cloudflare
+pnpm --filter @feedbax/site smoke -- \
+  https://feedbax-docs.jessefquartey.workers.dev
+```
+
+The Worker falls back to the application shell for unknown client-side routes and receives no Notion or portal secrets.
+
 ## Portal deployment support
 
 **Preview available.** Packed generated projects pass production builds for Cloudflare Workers, Vercel Node, and Node 22/Docker. The portal release gates cover SSR, server functions and routes, server-only environment access, secure cookies, cache behavior, validated mutations, sanitized errors, and secret exclusion.

--- a/apps/site/content/docs/notion-setup.mdx
+++ b/apps/site/content/docs/notion-setup.mdx
@@ -9,6 +9,19 @@ Notion is the only connector targeted for v0.1.0. Future connectors are directio
 
 Feedbax reads `NOTION_TOKEN` only on the server and reads the data-source ID and mappings from `feedbax.config.mjs`. Never expose the token through a `VITE_` variable.
 
+The starter template contains schemas and dashboard content only. Notion does not copy integration credentials or production identifiers when it is duplicated. Every operator must create a workspace integration, connect the duplicated page, and configure:
+
+[Duplicate the official Feedbax Notion starter](https://brave-number-c98.notion.site/Feedbax-Notion-Starter-39dafe1596918155a94cc24a1a41a2a5).
+
+```dotenv
+NOTION_TOKEN=
+NOTION_DATA_SOURCE_ID=
+NOTION_VOTES_DATA_SOURCE_ID=
+NOTION_COMMENTS_DATA_SOURCE_ID=
+NOTION_CHANGELOG_DATA_SOURCE_ID=
+FEEDBAX_SESSION_SECRET=
+```
+
 ## Prepare a workspace
 
 1. Create a Notion integration for the target workspace.

--- a/apps/site/content/docs/quickstart.mdx
+++ b/apps/site/content/docs/quickstart.mdx
@@ -12,15 +12,21 @@ description: Generate, configure, validate, and run a Notion-backed Feedbax port
 ## Create a project
 
 ```sh
-npx create-feedbax@latest my-feedback
+npx create-feedbax@latest my-feedback --yes \
+  --identity email \
+  --deploy cloudflare \
+  --package-manager pnpm \
+  --preset feedbax-default
 cd my-feedback
 ```
 
-Choose anonymous, email-only, or signed handoff identity. Email-only captures an unverified address; it does not authenticate ownership.
+This is the recommended founder path: Notion owns the data, email-only captures an unverified address for follow-up, and Cloudflare runs the portal. Email-only does not authenticate ownership.
 
 ## Configure and validate
 
-Copy `.env.example` to `.env`, set the documented server-only Notion and session values, then run:
+Duplicate the Feedbax Notion starter or provision the four databases yourself. A duplicated template never includes an integration token or reusable data-source IDs. Create your own Notion integration, connect it to the duplicated page, then copy the feedback, votes, comments, and changelog data-source IDs into `.env` together with a random session secret of at least 32 bytes.
+
+Copy `.env.example` to `.env`, set the documented server-only values, then run:
 
 ```sh
 npx feedbax doctor

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite dev --port 3001",
     "build": "vite build && node scripts/check-static.mjs",
+    "deploy:cloudflare": "pnpm build && wrangler deploy",
+    "smoke": "node scripts/smoke.mjs",
     "start": "node .output/server/index.mjs",
     "type-check": "tsc --noEmit",
     "lint": "eslint src *.ts",
@@ -35,6 +37,7 @@
     "@vitejs/plugin-react": "5.1.4",
     "nitro": "3.0.260610-beta",
     "tailwindcss": "^4.3.2",
-    "vite": "7.3.6"
+    "vite": "7.3.6",
+    "wrangler": "4.110.0"
   }
 }

--- a/apps/site/scripts/check-static.mjs
+++ b/apps/site/scripts/check-static.mjs
@@ -1,4 +1,4 @@
-import { access, readFile } from 'node:fs/promises'
+import { access, copyFile, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
 const routes = [
@@ -25,5 +25,8 @@ for (const route of routes) {
   if (!html.includes('feedbax'))
     throw new Error(`Static route is missing Feedbax shell: /${route}`)
 }
+
+// Cloudflare's asset worker expects an index document for the root route.
+await copyFile(resolve(output, '_shell.html'), resolve(output, 'index.html'))
 
 console.log(`Verified ${routes.length} independently deployable static routes.`)

--- a/apps/site/scripts/smoke.mjs
+++ b/apps/site/scripts/smoke.mjs
@@ -1,0 +1,14 @@
+const base = (
+  process.argv.find((value) => /^https?:\/\//.test(value)) ?? ''
+).replace(/\/$/, '')
+if (!base) throw new Error('Usage: node scripts/smoke.mjs <deployment-url>')
+
+for (const path of ['/', '/docs', '/docs/quickstart', '/docs/notion-setup']) {
+  const response = await fetch(`${base}${path}`)
+  if (!response.ok) throw new Error(`${path} returned ${response.status}.`)
+  const html = await response.text()
+  if (!html.toLowerCase().includes('feedbax'))
+    throw new Error(`${path} did not return the Feedbax site.`)
+}
+
+console.log(`Verified Feedbax docs at ${base}.`)

--- a/apps/site/src/lib/site.ts
+++ b/apps/site/src/lib/site.ts
@@ -1,6 +1,8 @@
 export const githubUrl = 'https://github.com/jessequartey/feedbax'
 export const feedbackPortalUrl =
   'https://feedbax-feedback.jessefquartey.workers.dev'
+export const notionStarterUrl =
+  'https://brave-number-c98.notion.site/Feedbax-Notion-Starter-39dafe1596918155a94cc24a1a41a2a5'
 
 export const statusLabels = [
   'Available',

--- a/apps/site/wrangler.jsonc
+++ b/apps/site/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "feedbax-docs",
+  "compatibility_date": "2026-07-14",
+  "assets": {
+    "directory": ".output/public",
+    "not_found_handling": "single-page-application",
+  },
+  "observability": { "enabled": true },
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -19,11 +19,13 @@ Configure `FEEDBAX_SPIKE_MARKER` in each runtime. Run `pnpm notion:doctor` in a 
 
 Live evidence is recorded here after deployment. A provider build alone does not count as passing.
 
-| Target     | URL or identifier                                                                           | Runtime                         | Smoke result                      | Date       |
-| ---------- | ------------------------------------------------------------------------------------------- | ------------------------------- | --------------------------------- | ---------- |
-| Cloudflare | `https://feedbax-portal.jessefquartey.workers.dev` / `7daeb47c-36c5-43ac-b9f4-e0e20be35d5c` | workerd, 17 ms reported startup | Passed                            | 2026-07-11 |
-| Vercel     | `https://portal-tau-two-57.vercel.app` / `dpl_EkvzNoBtpU2Y1SQKNYfej6TiSh8C`                 | Node.js 22 via Nitro            | Passed                            | 2026-07-11 |
-| Docker     | image `feedbax-spike:local` / container `54c82966dae2`                                      | Node 22.18.0 Alpine             | Passed at `http://localhost:3001` | 2026-07-11 |
+| Target             | URL or identifier                                                                             | Runtime                                            | Smoke result                      | Date       |
+| ------------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------- | --------------------------------- | ---------- |
+| Cloudflare         | `https://feedbax-portal.jessefquartey.workers.dev` / `7daeb47c-36c5-43ac-b9f4-e0e20be35d5c`   | workerd, 17 ms reported startup                    | Passed                            | 2026-07-11 |
+| Cloudflare dogfood | `https://feedbax-feedback.jessefquartey.workers.dev` / `ad47e394-6e53-46d6-9aaa-3d57312995eb` | workerd, email-only identity, official Notion data | Passed                            | 2026-07-14 |
+| Cloudflare docs    | `https://feedbax-docs.jessefquartey.workers.dev` / `6a2f5549-0776-4021-95a5-e8595c55f3a1`     | static Worker assets                               | Passed                            | 2026-07-14 |
+| Vercel             | `https://portal-tau-two-57.vercel.app` / `dpl_EkvzNoBtpU2Y1SQKNYfej6TiSh8C`                   | Node.js 22 via Nitro                               | Passed                            | 2026-07-11 |
+| Docker             | image `feedbax-spike:local` / container `54c82966dae2`                                        | Node 22.18.0 Alpine                                | Passed at `http://localhost:3001` | 2026-07-11 |
 
 The Cloudflare deployment requires the application-local `wrangler.jsonc` so the Vite plugin emits the Worker server bundle; deploying only the generated client configuration produces an assets-only Worker. Vercel requires a `NITRO_PRESET=vercel` build and consumes `s-maxage` before sending `Cache-Control` to clients. Docker requires `CI=true` during the frozen pnpm install and a root `.dockerignore` to avoid copying host build artifacts.
 

--- a/docs/rebuild/RELEASE-EVIDENCE.md
+++ b/docs/rebuild/RELEASE-EVIDENCE.md
@@ -2,6 +2,15 @@
 
 Recorded on 2026-07-14 for PR #7.
 
+## Founder launch
+
+- Merged PR 7 after all required checks and CodeRabbit completed successfully.
+- Generated an email-only Cloudflare project from public npm packages in a clean temporary directory and passed installation/type-checking.
+- Provisioned fresh private official and sanitized starter Notion database sets; both passed `feedbax doctor`.
+- Deployed and smoked the docs Worker at `https://feedbax-docs.jessefquartey.workers.dev`.
+- Deployed and smoked the email-only dogfood portal at `https://feedbax-feedback.jessefquartey.workers.dev`; the live email route returns a secure HTTP-only session cookie.
+- Published the duplicable starter at `https://brave-number-c98.notion.site/Feedbax-Notion-Starter-39dafe1596918155a94cc24a1a41a2a5` with credentials and production identifiers excluded.
+
 ## npm publication
 
 The public registry resolves all five packages, and npm reports `jessequartey` as

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "type-check": "turbo run type-check",
     "lint": "turbo run lint",
     "check:boundaries": "node scripts/check-boundaries.mjs",
+    "check:contribution-reference": "node scripts/check-contribution-reference.mjs",
     "test": "turbo run test",
     "test:e2e": "playwright test --config playwright.e2e.config.ts",
     "test:notion-smoke": "playwright test --config playwright.notion.config.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       '@tanstack/react-start':
         specifier: 1.168.27
         version: 1.168.27(crossws@0.4.9(srvx@0.11.21))(esbuild@0.28.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(rolldown@1.1.5)(rollup@4.62.2)(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0))
+      jose:
+        specifier: 6.1.3
+        version: 6.1.3
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -213,6 +216,9 @@ importers:
       vite:
         specifier: 7.3.6
         version: 7.3.6(@types/node@24.10.13)(jiti@2.7.0)(lightningcss@1.32.0)
+      wrangler:
+        specifier: 4.110.0
+        version: 4.110.0(@cloudflare/workers-types@5.20260713.1)
 
   connectors/notion:
     dependencies:

--- a/scripts/check-contribution-reference.mjs
+++ b/scripts/check-contribution-reference.mjs
@@ -1,0 +1,30 @@
+const eventPath = process.env.GITHUB_EVENT_PATH
+if (!eventPath) {
+  console.log('No GitHub event; contribution reference check skipped.')
+  process.exit(0)
+}
+
+const { readFile } = await import('node:fs/promises')
+const event = JSON.parse(await readFile(eventPath, 'utf8'))
+const pullRequest = event.pull_request
+if (!pullRequest) {
+  console.log('Not a pull request; contribution reference check skipped.')
+  process.exit(0)
+}
+
+const body = pullRequest.body ?? ''
+const labels = (pullRequest.labels ?? []).map(({ name }) => name)
+const item =
+  /Feedbax item:\s*https:\/\/feedbax-feedback\.jessefquartey\.workers\.dev\/feedback\/[A-Za-z0-9_-]+/i.test(
+    body,
+  )
+const exception = labels.includes('feedbax-exempt')
+const reason = /Maintainer exception reason:\s*\S.+/i.test(body)
+
+if (!item && !(exception && reason)) {
+  throw new Error(
+    'Link a canonical Feedbax item, or have a maintainer apply feedbax-exempt and provide a reason.',
+  )
+}
+
+console.log(item ? 'Feedbax item linked.' : 'Maintainer exception recorded.')

--- a/scripts/provision-notion.mjs
+++ b/scripts/provision-notion.mjs
@@ -1,7 +1,7 @@
 const API = 'https://api.notion.com/v1'
 const VERSION = '2025-09-03'
 const token = process.env.NOTION_TOKEN?.trim()
-const parentPageId = process.env.NOTION_PARENT_PAGE_ID?.trim()
+let parentPageId = process.env.NOTION_PARENT_PAGE_ID?.trim()
 
 if (!token || !parentPageId) {
   throw new Error('NOTION_TOKEN and NOTION_PARENT_PAGE_ID are required.')
@@ -24,6 +24,39 @@ async function notion(path, init = {}) {
     )
   }
   return response.json()
+}
+
+const childPageTitle = process.env.NOTION_CHILD_PAGE_TITLE?.trim()
+if (childPageTitle) {
+  const child = await notion('/pages', {
+    method: 'POST',
+    body: JSON.stringify({
+      parent: { type: 'page_id', page_id: parentPageId },
+      properties: {
+        title: {
+          title: [{ type: 'text', text: { content: childPageTitle } }],
+        },
+      },
+      children: [
+        {
+          object: 'block',
+          type: 'paragraph',
+          paragraph: {
+            rich_text: [
+              {
+                type: 'text',
+                text: {
+                  content:
+                    'Duplicate this page, create your own Notion integration, connect the duplicate, and configure the four new data-source IDs. Credentials and production identifiers are never included.',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  })
+  parentPageId = child.id
 }
 
 const richText = () => ({ rich_text: {} })
@@ -142,9 +175,16 @@ async function createSet(label) {
   return { feedback, votes, comments, changelog }
 }
 
-const provisioned = {
-  dogfood: await createSet('Feedbax Dogfood'),
-  smoke: await createSet('Feedbax CI Smoke'),
-}
+const labels = (
+  process.env.NOTION_SET_LABELS ?? 'Feedbax Dogfood,Feedbax CI Smoke'
+)
+  .split(',')
+  .map((label) => label.trim())
+  .filter(Boolean)
+const provisioned = Object.fromEntries(
+  await Promise.all(
+    labels.map(async (label) => [label, await createSet(label)]),
+  ),
+)
 
-console.log(JSON.stringify(provisioned))
+console.log(JSON.stringify({ parentPageId, provisioned }))

--- a/scripts/seed-dogfood.mjs
+++ b/scripts/seed-dogfood.mjs
@@ -90,6 +90,60 @@ const items = [
     tags: ['API'],
   },
   {
+    title: 'Linear connector',
+    description:
+      'Map customer feedback and roadmap state to Linear while preserving Feedbax connector boundaries.',
+    type: 'Feature',
+    status: 'Open',
+    category: 'Integration',
+    tags: ['API'],
+  },
+  {
+    title: 'Google Sheets connector',
+    description:
+      'Support a spreadsheet backend for teams that are not ready for a work-tracking platform.',
+    type: 'Feature',
+    status: 'Open',
+    category: 'Integration',
+    tags: ['API'],
+  },
+  {
+    title: 'Generic API connector',
+    description:
+      'Publish a provider-neutral connector contract for custom backends and automation tools.',
+    type: 'Feature',
+    status: 'Open',
+    category: 'Integration',
+    tags: ['API'],
+  },
+  {
+    title: 'Status notifications and digest delivery',
+    description:
+      'Notify opted-in customers when feedback changes status or ships through pluggable adapters.',
+    type: 'Feature',
+    status: 'Open',
+    category: 'Feature',
+    tags: ['Dashboard'],
+  },
+  {
+    title: 'SQLite, Postgres, and Better Auth options',
+    description:
+      'Add stronger interaction stores and verified authentication after the Notion preview is stable.',
+    type: 'Feature',
+    status: 'Open',
+    category: 'Improvement',
+    tags: ['API'],
+  },
+  {
+    title: 'Import, export, and migration tools',
+    description:
+      'Let operators move feedback without losing ownership of their data.',
+    type: 'Improvement',
+    status: 'Open',
+    category: 'Improvement',
+    tags: ['Dashboard'],
+  },
+  {
     title: 'Make Cloudflare-only modules portable across build targets',
     description:
       'Rollout issue: the Durable Object environment import initially broke the portable Node build and development dependency scan. The Worker-only binding is now isolated in the Cloudflare entrypoint.',

--- a/templates/default/.env.example
+++ b/templates/default/.env.example
@@ -1,4 +1,9 @@
 # Server-only Notion integration token. Never expose this to browser code.
 NOTION_TOKEN=
+# IDs returned after duplicating/provisioning the four Notion databases.
+NOTION_DATA_SOURCE_ID=
+NOTION_VOTES_DATA_SOURCE_ID=
+NOTION_COMMENTS_DATA_SOURCE_ID=
+NOTION_CHANGELOG_DATA_SOURCE_ID=
 # At least 32 random bytes used to sign opaque visitor sessions.
 FEEDBAX_SESSION_SECRET=


### PR DESCRIPTION
## Summary

- launch the official email-only Feedbax portal backed by private Notion databases
- deploy the documentation and marketing site as a Cloudflare Worker
- publish and document the sanitized duplicable Notion starter
- enforce canonical dogfood item references for contributions
- record the clean public-package founder journey and deployment evidence

## Impact

Founders now have a reproducible Notion-first setup path, while Feedbax uses its own production portal as the canonical roadmap. Email identity is an opaque, secure-cookie session and production Notion credentials remain Worker secrets.

## Verification

- full formatting, lint, type-check, and test suite passed
- Notion doctor passed for official and starter database sets
- live docs and portal Worker smoke suites passed
- valid, missing, and maintainer-exempt contribution reference cases exercised
- signed-out public template inspection confirmed sanitized content

Feedbax item: https://feedbax-feedback.jessefquartey.workers.dev/feedback/39dafe15-9691-8116-9436-e69a2f4c8d49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email-only authentication with secure session handling.
  * Added Cloudflare deployment support for the documentation site, including deployment and smoke-test commands.
  * Added a duplicable Notion starter with clearer setup guidance.
  * Expanded starter roadmap items for connectors, notifications, authentication, and data migration.

* **Documentation**
  * Updated quickstart, deployment, Notion setup, and contribution guidance.

* **Chores**
  * Added automated checks requiring pull requests to reference an approved roadmap item or documented exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->